### PR TITLE
fix(ngcc): do not compile JavaScript sources if typings-only processi…

### DIFF
--- a/packages/compiler-cli/ngcc/src/execution/analyze_entry_points.ts
+++ b/packages/compiler-cli/ngcc/src/execution/analyze_entry_points.ts
@@ -49,11 +49,8 @@ export function getAnalyzeEntryPointsFn(
 
     for (const entryPoint of entryPoints) {
       const packageJson = entryPoint.packageJson;
-      const hasProcessedTypings = hasBeenProcessed(packageJson, 'typings');
       const {propertiesToProcess, equivalentPropertiesMap} = getPropertiesToProcess(
           packageJson, supportedPropertiesToConsider, compileAllFormats, typingsOnly);
-      let processDts = hasProcessedTypings ? DtsProcessing.No :
-                                             typingsOnly ? DtsProcessing.Only : DtsProcessing.Yes;
 
       if (propertiesToProcess.length === 0) {
         // This entry-point is unprocessable (i.e. there is no format property that is of interest
@@ -63,6 +60,16 @@ export function getAnalyzeEntryPointsFn(
         unprocessableEntryPointPaths.push(entryPoint.path);
         continue;
       }
+
+      const hasProcessedTypings = hasBeenProcessed(packageJson, 'typings');
+      if (hasProcessedTypings && typingsOnly) {
+        // Typings for this entry-point have already been processed and we're in typings-only mode,
+        // so no task has to be created for this entry-point.
+        logger.debug(`Skipping ${entryPoint.name} : typings have already been processed.`);
+        continue;
+      }
+      let processDts = hasProcessedTypings ? DtsProcessing.No :
+                                             typingsOnly ? DtsProcessing.Only : DtsProcessing.Yes;
 
       for (const formatProperty of propertiesToProcess) {
         if (hasBeenProcessed(entryPoint.packageJson, formatProperty)) {


### PR DESCRIPTION
…ng is repeated

The recently introduced typings-only mode in ngcc would incorrectly
write compiled JavaScript files if typings-only mode was requested, in
case the typings of the entry-point had already been processed in a
prior run of ngcc. The corresponding format property for which the
JavaScript files were written were not marked as processed, though, as
the typings-only mode excluded the format property itself from being
marked as processed. Consequently, subsequent runs of ngcc would not
consider the entry-point to have been processed and recompile the
JavaScript bundle once more, resulting in duplicate ngcc imports.

Fixes #41198

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
